### PR TITLE
Improve translatable strings

### DIFF
--- a/res/scripts/commands/top10Command.js
+++ b/res/scripts/commands/top10Command.js
@@ -10,11 +10,11 @@ $.getTimeString = function (time) {
     var s = $.lang.get("net.phantombot.common.time-suffixes");
 
     if (p.length != 4) {
-        $.logError("./systems/raidSystem.js", 47, "The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
+        $.logError("./systems/top10Command.js", 9, "The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
         println("[raidSystem.js] The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
         return minutes;
     } else if (s.length != 4) {
-        $.logError("./systems/raidSystem.js", 48, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
+        $.logError("./systems/top10Command.js", 10, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
         println("[raidSystem.js] The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
         return minutes;
     }

--- a/res/scripts/commands/top10Command.js
+++ b/res/scripts/commands/top10Command.js
@@ -6,32 +6,40 @@ $.getTimeString = function (time) {
 
     var timeString = "";
 
-    if (time > 0) {
-        if (weeks > 0) {
-            timeString += weeks.toString();
-            timeString += "w "
-        }
-        if (days > 0) {
-            timeString += days.toString();
-            timeString += "d "
-        }
-        if (hours > 0) {
-            timeString += hours.toString();
-            timeString += "h "
-        }
-        if (minutes > 0) {
-            timeString += minutes.toString();
-            timeString += "m "
-        }
-        if (weeks == 0 && days == 0 && hours == 0 && minutes == 0) {
-            return "0s";
-        }
+    var p = $.lang.get("net.phantombot.common.time-prefixes");
+    var s = $.lang.get("net.phantombot.common.time-suffixes");
 
-        timeString = timeString.trim();
-    } else {
-        return "0s";
+    if (p.length != 4) {
+        $.logError("./systems/raidSystem.js", 47, "The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
+        println("[raidSystem.js] The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
+        return minutes;
+    } else if (s.length != 4) {
+        $.logError("./systems/raidSystem.js", 48, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
+        println("[raidSystem.js] The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
+        return minutes;
     }
 
+    if (time > 0) {
+        if (weeks > 0) {
+            timeString += p[0] + weeks.toString() + s[0] + " ";
+        }
+        if (days > 0) {
+            timeString += p[1] + days.toString() + s[1] + " ";
+        }
+        if (hours > 0) {
+            timeString += p[2] + hours.toString() + s[2] + " ";
+        }
+        if (minutes > 0) {
+            timeString += p[3] + minutes.toString() + s[3] + " ";
+        }
+        if (weeks == 0 && days == 0 && hours == 0 && minutes == 0) {
+            timeString += p[3] + "0" + s[3] + " ";
+        }
+    } else {
+        timeString += p[3] + "0" + s[3] + " ";
+    }
+
+    timeString = timeString.trim();
     return timeString;
 }
 

--- a/res/scripts/lang/lang-english.js
+++ b/res/scripts/lang/lang-english.js
@@ -12,6 +12,18 @@ $.lang.data["net.phantombot.common.user-404"] = "The user \"$1\" has not visited
 $.lang.data["net.phantombot.common.whisper-disabled"] = "[Whisper Mode] has been disabled.";
 $.lang.data["net.phantombot.common.whisper-enabled"] = "[Whisper Mode] has been enabled.";
 
+// To translate the ordinal number prefixes or suffixes, edit the lines below.
+// Warning: Make sure each line contains 10 items total; 0 through 9.
+// Order: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].
+$.lang.data["net.phantombot.common.ordinal-prefixes"] = ["","","","", "", "", "", "", "", ""];
+$.lang.data["net.phantombot.common.ordinal-suffixes"] = ["th","st","nd","rd", "th", "th", "th", "th", "th", "th"];
+
+// To translate the time prefixes or suffixes, edit the lines below. This is used for both a single w/d/h/m and multiple w/d/h/m.
+// Warning: Make sure each line contains 4 items total; w, d, h, m.
+// Order: [w, d, h, m].
+$.lang.data["net.phantombot.common.time-prefixes"] = ["","","",""];
+$.lang.data["net.phantombot.common.time-suffixes"] = ["w","d","h","m"];
+
 //command perm/price
 $.lang.data["net.phantombot.cmd.noperm"] = "Your user group, $1, does not have permission to use the command $2.";
 $.lang.data["net.phantombot.cmd.needpoints"] = "That command costs $1, which you don't have.";
@@ -188,10 +200,12 @@ $.lang.data["net.phantombot.uptime.success-online"] = "/me [Stream Uptime] $1 ha
 $.lang.data["net.phantombot.uptime.success-offline"] = "$1 is currently not streaming.";
 $.lang.data["net.phantombot.botuptime.success"] = "/me [Bot Uptime] $1 has been online for $2.";
 
-
 // raidSystem.js
-$.lang.data["net.phantombot.raidsystem.success"] = "Thank you for the raid, $1! This is the $2 time $1 has raided! Please give them a follow at \"http://twitch.tv/$3\"!";
-$.lang.data["net.phantombot.raidsystem.usage"] = "Usage: \"!raider <name>\"";
+$.lang.data["net.phantombot.raidsystem.raid-error-toomuch"] = "To prevent a global ban from Twitch, the maximum has been set to $1.";
+$.lang.data["net.phantombot.raidsystem.raid-success"] = "/me \"http://www.twitch.tv/$1\"";
+$.lang.data["net.phantombot.raidsystem.raid-usage"] = "Usage: \"!raid <name> [<amount>]\"";
+$.lang.data["net.phantombot.raidsystem.raider-success"] = "Thank you for the raid, $1! This is the $2 time $1 has raided! Please give them a follow at \"http://twitch.tv/$3\"!";
+$.lang.data["net.phantombot.raidsystem.raider-usage"] = "Usage: \"!raider <name>\"";
 
 //addCommand.js
 $.lang.data["net.phantombot.addcommand.addcom-success"] = "$1, has successfully created the command: !$2";

--- a/res/scripts/systems/pointSystem.js
+++ b/res/scripts/systems/pointSystem.js
@@ -99,11 +99,11 @@ $.getTimeString = function (time) {
     var s = $.lang.get("net.phantombot.common.time-suffixes");
 
     if (p.length != 4) {
-        $.logError("./systems/raidSystem.js", 47, "The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
+        $.logError("./systems/pointSystem.js", 98, "The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
         println("[raidSystem.js] The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
         return minutes;
     } else if (s.length != 4) {
-        $.logError("./systems/raidSystem.js", 48, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
+        $.logError("./systems/raidSystem.js", 99, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
         println("[raidSystem.js] The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
         return minutes;
     }

--- a/res/scripts/systems/pointSystem.js
+++ b/res/scripts/systems/pointSystem.js
@@ -103,7 +103,7 @@ $.getTimeString = function (time) {
         println("[raidSystem.js] The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
         return minutes;
     } else if (s.length != 4) {
-        $.logError("./systems/raidSystem.js", 99, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
+        $.logError("./systems/pointSystem.js", 99, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
         println("[raidSystem.js] The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
         return minutes;
     }

--- a/res/scripts/systems/pointSystem.js
+++ b/res/scripts/systems/pointSystem.js
@@ -95,32 +95,40 @@ $.getTimeString = function (time) {
 
     var timeString = "";
 
-    if (time > 0) {
-        if (weeks > 0) {
-            timeString += weeks.toString();
-            timeString += "w "
-        }
-        if (days > 0) {
-            timeString += days.toString();
-            timeString += "d "
-        }
-        if (hours > 0) {
-            timeString += hours.toString();
-            timeString += "h "
-        }
-        if (minutes > 0) {
-            timeString += minutes.toString();
-            timeString += "m "
-        }
-        if (weeks == 0 && days == 0 && hours == 0 && minutes == 0) {
-            return false;
-        }
+    var p = $.lang.get("net.phantombot.common.time-prefixes");
+    var s = $.lang.get("net.phantombot.common.time-suffixes");
 
-        timeString = timeString.trim();
-    } else {
-        return "0s";
+    if (p.length != 4) {
+        $.logError("./systems/raidSystem.js", 47, "The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
+        println("[raidSystem.js] The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
+        return minutes;
+    } else if (s.length != 4) {
+        $.logError("./systems/raidSystem.js", 48, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
+        println("[raidSystem.js] The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
+        return minutes;
     }
 
+    if (time > 0) {
+        if (weeks > 0) {
+            timeString += p[0] + weeks.toString() + s[0] + " ";
+        }
+        if (days > 0) {
+            timeString += p[1] + days.toString() + s[1] + " ";
+        }
+        if (hours > 0) {
+            timeString += p[2] + hours.toString() + s[2] + " ";
+        }
+        if (minutes > 0) {
+            timeString += p[3] + minutes.toString() + s[3] + " ";
+        }
+        if (weeks == 0 && days == 0 && hours == 0 && minutes == 0) {
+            timeString += p[3] + "0" + s[3] + " ";
+        }
+    } else {
+        timeString += p[3] + "0" + s[3] + " ";
+    }
+
+    timeString = timeString.trim();
     return timeString;
 }
 

--- a/res/scripts/systems/raidSystem.js
+++ b/res/scripts/systems/raidSystem.js
@@ -1,7 +1,21 @@
+var maxSpamCount = 10;
+
 $.getOrdinal = function (n) {
-   var s = ["th","st","nd","rd"],
-       v = n % 100;
-   return n + (s[(v - 20) % 10] || s[v] || s[0]);
+    var p = $.lang.get("net.phantombot.common.ordinal-prefixes");
+    var s = $.lang.get("net.phantombot.common.ordinal-suffixes");
+    var v = n % 100;
+
+    if (p.length == 10 && s.length == 10) {
+        return (p[(v - 20) % 10] || p[v] || p[0]) + n + (s[(v - 20) % 10] || s[v] || s[0]);
+    } else if (p.length != 10) {
+        $.logError("./systems/raidSystem.js", 6, "The ordinal prefixes did not contain all numbers. String: net.phantombot.common.ordinal-prefixes");
+        println("[raidSystem.js] The ordinal prefixes did not contain all numbers. String: net.phantombot.common.ordinal-prefixes");
+        return n;
+    } else if (s.length != 10) {
+        $.logError("./systems/raidSystem.js", 7, "The ordinal suffixes did not contain all numbers. String: net.phantombot.common.ordinal-suffixes");
+        println("[raidSystem.js] The ordinal suffixes did not contain all numbers. String: net.phantombot.common.ordinal-suffixes");
+        return n;
+    }
 }
 
 $.on('command', function(event) {
@@ -18,33 +32,29 @@ $.on('command', function(event) {
     }
 
     if (command.equalsIgnoreCase("raid")) {
-        var s = "";
         if (args.length >= 1) {
             if (!$.isModv3(sender, event.getTags())) {
                 $.say($.getWhisperString(sender) + $.modmsg);
                 return;
             }
-            if (args.length >=2 ) {
-                
-            }
-            if($.username.resolve(args[0])) {
-                s = 'http://www.twitch.tv/' + args[0].toLowerCase();  
-            }
-            if (args.length >=2 && parseInt(args[1]) ) {
-                if(parseInt(args[1]) > 10 ) {
-                    $.say($.getWhisperString(sender) + "The max raid spam is set to 10 lines to prevent global chat bans.");
+
+            if (args.length >=2 && !isNaN(parseInt(args[1]))) {
+                if(parseInt(args[1]) > maxSpamCount) {
+                    $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.raidsystem.raid-error-toomuch", maxSpamCount));
                     return;
                 }
-                for(var i=0; i<parseInt(args[1]); i++) {
-                    $.say(s);
+
+                for(var i = 0; i < parseInt(args[1]); i++) {
+                    $.say($.lang.get("net.phantombot.raidsystem.raid-success", args[0].toLowerCase()));
                 }
+
                 return;
             } else {
-                $.say(s);
+                $.say($.lang.get("net.phantombot.raidsystem.raid-success", args[0].toLowerCase()));
+                return;
             }
-            return;
         } else {
-            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.raidsystem.usage"));       
+            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.raidsystem.raid-usage"));       
             return;
         }
     }
@@ -58,10 +68,10 @@ $.on('command', function(event) {
 
             $.inidb.incr('raiders', args[0].toLowerCase() + "_count", 1);
 
-            $.say($.lang.get("net.phantombot.raidsystem.success", $.username.resolve(args[0]), getOrdinal($.inidb.get('raiders', args[0].toLowerCase()  + "_count")), args[0].toLowerCase()));  
+            $.say($.lang.get("net.phantombot.raidsystem.raider-success", $.username.resolve(args[0]), getOrdinal($.inidb.get('raiders', args[0].toLowerCase()  + "_count")), args[0].toLowerCase()));  
             return;
         } else {
-            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.raidsystem.usage"));       
+            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.raidsystem.raider-usage"));       
             return;
         }
     }

--- a/res/scripts/systems/timeSystem.js
+++ b/res/scripts/systems/timeSystem.js
@@ -51,32 +51,40 @@ $.getTimeString = function (time) {
 
     var timeString = "";
 
-    if (time > 0) {
-        if (weeks > 0) {
-            timeString += weeks.toString();
-            timeString += "w "
-        }
-        if (days > 0) {
-            timeString += days.toString();
-            timeString += "d "
-        }
-        if (hours > 0) {
-            timeString += hours.toString();
-            timeString += "h "
-        }
-        if (minutes > 0) {
-            timeString += minutes.toString();
-            timeString += "m "
-        }
-        if (weeks == 0 && days == 0 && hours == 0 && minutes == 0) {
-            return "0m";
-        }
+    var p = $.lang.get("net.phantombot.common.time-prefixes");
+    var s = $.lang.get("net.phantombot.common.time-suffixes");
 
-        timeString = timeString.trim();
-    } else {
-        return "0m";
+    if (p.length != 4) {
+        $.logError("./systems/raidSystem.js", 47, "The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
+        println("[raidSystem.js] The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
+        return minutes;
+    } else if (s.length != 4) {
+        $.logError("./systems/raidSystem.js", 48, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
+        println("[raidSystem.js] The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
+        return minutes;
     }
 
+    if (time > 0) {
+        if (weeks > 0) {
+            timeString += p[0] + weeks.toString() + s[0] + " ";
+        }
+        if (days > 0) {
+            timeString += p[1] + days.toString() + s[1] + " ";
+        }
+        if (hours > 0) {
+            timeString += p[2] + hours.toString() + s[2] + " ";
+        }
+        if (minutes > 0) {
+            timeString += p[3] + minutes.toString() + s[3] + " ";
+        }
+        if (weeks == 0 && days == 0 && hours == 0 && minutes == 0) {
+            timeString += p[3] + "0" + s[3] + " ";
+        }
+    } else {
+        timeString += p[3] + "0" + s[3] + " ";
+    }
+
+    timeString = timeString.trim();
     return timeString;
 }
 

--- a/res/scripts/systems/timeSystem.js
+++ b/res/scripts/systems/timeSystem.js
@@ -55,11 +55,11 @@ $.getTimeString = function (time) {
     var s = $.lang.get("net.phantombot.common.time-suffixes");
 
     if (p.length != 4) {
-        $.logError("./systems/raidSystem.js", 47, "The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
+        $.logError("./systems/timeSystem.js", 54, "The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
         println("[raidSystem.js] The time prefixes did not contain all numbers. String: net.phantombot.common.time-prefixes");
         return minutes;
     } else if (s.length != 4) {
-        $.logError("./systems/raidSystem.js", 48, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
+        $.logError("./systems/timeSystem.js", 55, "The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
         println("[raidSystem.js] The time suffixes did not contain all numbers. String: net.phantombot.common.time-suffixes");
         return minutes;
     }


### PR DESCRIPTION
Fixes / Changes:
  - [raidSystem] Export strings to lang.
  - [raidSystem] Make maxSpamCount a variable to allow manual change.
  - [raidSystem] Remove some redundant code.
  - [Multiple] Allow ordinal numbers' pre- and suffixes to be translated. (0th - 9th)
  - [Multiple] Allow time measurements' pre- and suffixes to be translated. (week, day, hour, minute)
  - [Multiple] Get rid of "return: false;" in all getTimeString functions.