### PR TITLE
[greetingSystem.js] Complete Redo

### DIFF
--- a/res/scripts/lang/lang-english.js
+++ b/res/scripts/lang/lang-english.js
@@ -360,3 +360,27 @@ $.lang.data["net.phantombot.top10.time-disabled"] = "You can not use this comman
 $.lang.data["net.phantombot.top10.time-error-noresults"] = "Could not find any users with time spent in the chat.";
 $.lang.data["net.phantombot.top10.time-success"] = "/me [Top 10 Time] $1";
 $.lang.data["net.phantombot.top10.time-success-whisper"] = "[Top 10 Time] $1";
+
+// greetingSystem.js
+$.lang.data["net.phantombot.greetingsystem.maxchars-error-negative"] = "You can not set the maximum greeting character amount to a negative number.";
+$.lang.data["net.phantombot.greetingsystem.maxchars-success"] = "Set the maximum greeting character amount to $1.";
+$.lang.data["net.phantombot.greetingsystem.maxchars-usage"] = "Usage: \"!greet max <amount>\"";
+$.lang.data["net.phantombot.greetingsystem.set-cleared"] = "Your greeting message has been reset.";
+$.lang.data["net.phantombot.greetingsystem.set-cleared-global"] = "The default greeting message has been reset.";
+$.lang.data["net.phantombot.greetingsystem.set-cleared-other"] = "The greeting message of $1 has been reset.";
+$.lang.data["net.phantombot.greetingsystem.set-error-noname"] = "Your greeting message must contain \"(name)\" to display your name.";
+$.lang.data["net.phantombot.greetingsystem.set-error-noname-global"] = "The default greeting message must contain \"(name)\" to display someone's name.";
+$.lang.data["net.phantombot.greetingsystem.set-error-noname-other"] = "The greeting message of $1 must contain \"(name)\" to display their name.";
+$.lang.data["net.phantombot.greetingsystem.set-error-toolong"] = "Your greeting message can not be longer than $1 characters. It is now $2 characters long.";
+$.lang.data["net.phantombot.greetingsystem.set-error-toolong-global"] = "The default greeting message can not be longer than $1 characters. It is now $2 characters long.";
+$.lang.data["net.phantombot.greetingsystem.set-error-toolong-other"] = "The greeting message of $1 can not be longer than $2 characters. It is now $3 characters long.";
+$.lang.data["net.phantombot.greetingsystem.set-success"] = "Your greeting message has been set to \"$1\".";
+$.lang.data["net.phantombot.greetingsystem.set-success-global"] = "The default greeting message has been set to \"$1\".";
+$.lang.data["net.phantombot.greetingsystem.set-success-other"] = "The greeting message of $1 has been set to \"$2\".";
+$.lang.data["net.phantombot.greetingsystem.toggle-disabled"] = "A greeting message will no longer be displayed when you join.";
+$.lang.data["net.phantombot.greetingsystem.toggle-disabled-global"] = "A greeting message will no longer be displayed when anyone joins.";
+$.lang.data["net.phantombot.greetingsystem.toggle-disabled-other"] = "A greeting message will no longer be displayed when $1 joins.";
+$.lang.data["net.phantombot.greetingsystem.toggle-enabled"] = "A greeting message will now be displayed when you join.";
+$.lang.data["net.phantombot.greetingsystem.toggle-enabled-global"] = "A greeting message will now be displayed when anyone joins.";
+$.lang.data["net.phantombot.greetingsystem.toggle-enabled-other"] = "A greeting message will now be displayed when $1 joins.";
+$.lang.data["net.phantombot.greetingsystem.usage"] = "Usage: \"!greet max <amount>\", \"!greet set [global OR user <name>] <message>\", \"!greet toggle [global OR user <name>]\"";

--- a/res/scripts/systems/greetingSystem.js
+++ b/res/scripts/systems/greetingSystem.js
@@ -1,140 +1,227 @@
-$.on('ircChannelJoin', function(event) {
-    var sender = event.getUser().toLowerCase();
-    var username = $.username.resolve(sender);
-    var s = $.inidb.get("greeting", sender);
+$.greetMaxChars = parseInt($.inidb.get("settings", "greeting_max_chars"));
+$.greetGlobal = $.inidb.get("greeting", "_default");
+$.greetToggleGlobal = $.inidb.get("greeting", "autogreet");
 
-    $.inidb.set("visited", sender.toLowerCase(), "visited");
-    
-    if ($.inidb.get("greeting", sender + "_enabled") == "1") {
+if ($.greetMaxChars == undefined || $.greetMaxChars == null || isNaN($.greetMaxChars) || $.greetMaxChars < 0) {
+    $.greetMaxChars = 80;
+}
 
-        if (s == null || s == undefined || s.isEmpty()) {
-            s = $.inidb.get("greeting", "_default");
-            
-            if (s == null || s == undefined || s.isEmpty()) {
-                s = "(name) has entered the channel!";
-            }
-        }
-        
-        $.say($.getWhisperString(sender) + s.replace("(name)", username));
-        
-    } else if ($.inidb.get("greeting", "autogreet") == "true") {
-        if (s == null || s == undefined || s.isEmpty()) {
-            s = $.inidb.get("greeting", "_default");
-            
-            if (s == null || s == undefined || s.isEmpty()) {
-                s = "(name) has entered the channel!";
-            }
-        }
-        
-        $.say($.getWhisperString(sender) + s.replace("(name)", username));
-           
-    } else {
-    //println("[Join] " + username + " has joined the channel.");
-    } 
-});
+if ($.greetGlobal == undefined || $.greetGlobal == null) {
+    $.greetGlobal = "(name) has entered the channel!";
+}
 
-$.on('ircChannelLeave', function(event) {
-    var sender = event.getUser().toLowerCase();
-    var username = $.username.resolve(sender);
-    
-//println("[Leave] " + username + " has left the channel.");
-});
+if ($.greetToggleGlobal == undefined || $.greetToggleGlobal == null) {
+    $.greetToggleGlobal = "true";
+}
 
-$.on('command', function(event) {
+$.on("command", function (event) {
     var sender = event.getSender().toLowerCase();
     var username = $.username.resolve(sender, event.getTags());
     var command = event.getCommand();
     var argsString = event.getArguments().trim();
-    var args = event.getArgs();
-    var subCommand;
-    
-    if(command.equalsIgnoreCase("greeting")) {
-        if (argsString.isEmpty()){
-            subCommand = "";
-        } else {
-            subCommand = args[0];
-        }
-        
-        var message = "";
-            
-        if (args.length > 1) {
-            message = argsString.substring(argsString.indexOf(subCommand) + $.strlen(subCommand) + 1);
-        }
-        
-        if (subCommand.equalsIgnoreCase("toggle")) {
-            if (!$.isModv3(sender, event.getTags())) {
-                $.say($.getWhisperString(sender) + $.modmsg);
-                return;
-            }
-            if ($.inidb.get("greeting", "autogreet")== null || $.inidb.get("greeting", "autogreet")== "false") {
-                $.inidb.set("greeting", "autogreet", "true");
-                $.say($.getWhisperString(sender) + "Auto Greeting enabled! " + $.username.resolve($.botname) + " will greet everyone from now on.");
-            } else if ($.inidb.get("greeting", "autogreet")== "true") {
-                $.inidb.set("greeting", "autogreet", "false");
-                $.say($.getWhisperString(sender) + "Auto Greeting disabled! " + $.username.resolve($.botname) + " will no longer greet viewers.");
-            }
-        }
+    var args;
 
-        if (subCommand.equalsIgnoreCase("enable")) {
-            $.inidb.set("greeting", sender + "_enabled", "1");
-         
-            $.say ($.getWhisperString(sender) + "Greeting enabled! " + $.username.resolve($.botname) + " will greet you from now on " + username + ".");
-        } else if (subCommand.equalsIgnoreCase("disable")) {
-            $.inidb.set("greeting", sender + "_enabled", "0");
-            
-            $.say ($.getWhisperString(sender) + "Greeting disabled for " + username);
-        } else if (subCommand.equalsIgnoreCase("set")) {
-            if ($.strlen(message) == 0) {
-                $.inidb.set("greeting", sender, "");
-                $.say($.getWhisperString(sender) + "Greeting deleted");
-            }
-            
-            if (message.indexOf("(name)") == -1) {
-                $.say($.getWhisperString(sender) + "You must include '(name)' in your new greeting so I know where to insert your name, " + username + ". Example: !greeting set (name) sneaks into the channel!");
-                return;
-            }
-            
-            $.inidb.set("greeting", sender, message);
-            
-            $.say($.getWhisperString(sender) + "Greeting changed");
-        } else if (subCommand.equalsIgnoreCase("setdefault")) {
-            if (!$.isModv3(sender, event.getTags())) {
-                $.say($.getWhisperString(sender) + $.modmsg);
-                return;
-            }
-            
-            if (message.indexOf("(name)") == -1) {
-                $.say($.getWhisperString(sender) + "You must include '(name)' in the new greeting so I know where to insert the viewers name, " + username + ". Example: !greeting setdefault (name) sneaks into the channel!");
-                return;
-            }
-            
-            $.logEvent("greetingSystem.js", 75, username + " changed the default greeting to " + message);
-            
-            $.inidb.set("greeting", "_default", message);
-            
-            $.say($.getWhisperString(sender) + "Default greeting changed");
-        } else if (args[0].isEmpty()){
-            $.say($.getWhisperString(sender) + 'Usage: !greeting enable, !greeting disable, !greeting set (message), !greeting setdefault (message)');
-        }
+    if (argsString.isEmpty()) {
+        args = [];
+    } else {
+        args = argsString.split(" ");
     }
-    
-    if (command.equalsIgnoreCase("greet")) {
-        var s = $.inidb.get("greeting", sender);
-        
-        if (s == null || s == undefined || s.isEmpty()) {
-            s = $.inidb.get("greeting", "_default");
-            
-            if (s == null || s == undefined || s.isEmpty()) {
-                s = "(name) has entered the channel!";
+
+    if(command.equalsIgnoreCase("greet") || command.equalsIgnoreCase("greeting")) {
+        if (args.length >= 1) {
+            var action = args[0];
+
+            if (action.equalsIgnoreCase("toggle")) {
+                if (args.length > 1) {
+                    if ($.isModv3(sender, event.getTags()) && (args[1].equalsIgnoreCase("default") || args[1].equalsIgnoreCase("global"))) {
+                        if ($.greetToggleGlobal == "false") {
+                            $.inidb.set("greeting", "autogreet", "true");
+                            $.greetToggleGlobal = $.inidb.get("greeting", "autogreet");
+
+                            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.toggle-enabled-global"));
+                        } else if ($.greetToggleGlobal == "true") {
+                            $.inidb.set("greeting", "autogreet", "false");
+                            $.greetToggleGlobal = $.inidb.get("greeting", "autogreet");
+
+                            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.toggle-disabled-global"));
+                        }
+                    } else if ($.isModv3(sender, event.getTags()) && (!args[1].isEmpty())) {
+                        if (args[1].equalsIgnoreCase("user") && args[2] != undefined) {
+                            var greetuser = args[2].toLowerCase();
+                        } else {
+                            var greetuser = args[1].toLowerCase();
+                        }
+
+                        if ($.inidb.get("visited", greetuser) == "visited") {
+                            var greetToggle = $.inidb.get("greeting", greetuser + "_enabled");
+
+                            if (greetToggle == "false" || greetToggle == undefined || greetToggle == null) {
+                                $.inidb.set("greeting", greetuser + "_enabled", "true");
+                                greetToggle = $.inidb.get("greeting", greetuser + "_enabled");
+
+                                $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.toggle-enabled-other", $.username.resolve(greetuser)));
+                            } else if (greetToggle == "true") {
+                                $.inidb.set("greeting", greetuser + "_enabled", "false");
+                                greetToggle = $.inidb.get("greeting", greetuser + "_enabled");
+
+                                $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.toggle-disabled-other", $.username.resolve(greetuser)));
+                            }
+                        } else {
+                            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.common.user-404", $.username.resolve(greetuser)));
+                        }
+                    }
+                } else {
+                    var greetToggle = $.inidb.get("greeting", sender + "_enabled");
+
+                    if (greetToggle == "false" || greetToggle == undefined || greetToggle == null) {
+                        $.inidb.set("greeting", sender + "_enabled", "true");
+                        greetToggle = $.inidb.get("greeting", sender + "_enabled");
+
+                        $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.toggle-enabled"));
+                    } else if (greetToggle == "true") {
+                        $.inidb.set("greeting", sender + "_enabled", "false");
+                        greetToggle = $.inidb.get("greeting", sender + "_enabled");
+
+                        $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.toggle-disabled"));
+                    }
+                }
+            } else if (action.equalsIgnoreCase("set")) {
+                if (args.length > 1) {
+                    if ($.isModv3(sender, event.getTags()) && (args[1].equalsIgnoreCase("default") || args[1].equalsIgnoreCase("global"))) {
+                        var message = argsString.substring(argsString.indexOf(args[1]) + $.strlen(args[1]) + 1);
+
+                        if ($.strlen(message) == 0) {
+                            $.inidb.set("greeting", "_default", $.greetGlobalDefault);
+                            $.greetGlobal = $.inidb.get("greeting", "_default");
+
+                            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-cleared-global"));
+                        } else if ($.strlen(message) > $.greetMaxChars) {
+                            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-error-toolong-global", $.greetMaxChars, $.strlen(message)));
+                        } else {
+                            if (message.indexOf("(name)") != -1) {
+                                $.inidb.set("greeting", "_default", message.trim());
+                                $.greetGlobal = $.inidb.get("greeting", "_default");
+
+                                $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-success-global", $.greetGlobal));
+                            } else {
+                                $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-error-noname-global"));
+                            }
+                        }
+                    } else if ($.isModv3(sender, event.getTags()) && (args[1].equalsIgnoreCase("user") && args[2] != undefined)) {
+                        var greetuser = args[2].toLowerCase();
+
+                        if ($.inidb.get("visited", greetuser) == "visited") {
+                            var greet = $.inidb.get("greeting", greetuser);
+                            var message = argsString.substring(argsString.indexOf(args[2]) + $.strlen(args[2]) + 1);
+
+                            if ($.strlen(message) == 0) {
+                                $.inidb.set("greeting", greetuser, "");
+                                greet = $.inidb.get("greeting", greetuser);
+
+                                $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-cleared-other", $.username.resolve(greetuser)));
+                            } else if ($.strlen(message) > $.greetMaxChars) {
+                                $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-error-toolong-other", $.username.resolve(greetuser), $.greetMaxChars, $.strlen(message)));
+                            } else {
+                                if (message.indexOf("(name)") != -1) {
+                                    $.inidb.set("greeting", greetuser, message.trim());
+                                    greet = $.inidb.get("greeting", greetuser);
+
+                                    $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-success-other", $.username.resolve(greetuser), greet.replace("(name)", $.username.resolve(greetuser))));
+                                } else {
+                                    $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-error-noname-other", $.username.resolve(greetuser)));
+                                }
+                            }
+                        } else {
+                            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.common.user-404", $.username.resolve(greetuser)));
+                        }
+                    } else {
+                        var greet = $.inidb.get("greeting", sender);
+                        var message = argsString.substring(argsString.indexOf(action) + $.strlen(action) + 1);
+
+                        if ($.strlen(message) == 0) {
+                            $.inidb.set("greeting", sender, "");
+                            greet = $.inidb.get("greeting", sender);
+
+                            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-cleared"));
+                        } else if ($.strlen(message) > $.greetMaxChars) {
+                            $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-error-toolong", $.greetMaxChars, $.strlen(message)));
+                        } else {
+                            if (message.indexOf("(name)") != -1) {
+                                $.inidb.set("greeting", sender, message.trim());
+                                greet = $.inidb.get("greeting", sender);
+
+                                $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-success", greet.replace("(name)", username)));
+                            } else {
+                                $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.set-error-noname"));
+                            }
+                        }
+                    }
+                } else {
+                    $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.usage"));
+                }
+            } else if (action.equalsIgnoreCase("max") || action.equalsIgnoreCase("setmax") || action.equalsIgnoreCase("maxchars")) {
+                if (!$.isAdmin(sender)) {
+                    $.say($.getWhisperString(sender) + $.adminmsg);
+                    return;
+                }
+
+                if (args[1] == null || isNaN(parseInt(args[1]))) {
+                    $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.maxchars-usage"));
+                    return;
+                }
+
+                if (args[1] < 0) {
+                    $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.maxchars-error-negative"));
+                    return;
+                } else {
+                    $.inidb.set("settings", "greeting_max_chars", args[1]);
+                    $.greetMaxChars = parseInt($.inidb.get("settings", "greeting_max_chars"));
+
+                    $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.maxchars-success", $.greetMaxChars));
+                    return;
+                }
+            } else {
+                $.say($.getWhisperString(sender) + $.lang.get("net.phantombot.greetingsystem.usage"));
+            }
+        } else {
+            var greet = $.inidb.get("greeting", sender);
+
+            if (greet == null || greet == undefined || greet == "") {
+                $.say($.getWhisperString(sender) + $.greetGlobal.replace("(name)", username));
+            } else {
+                $.say($.getWhisperString(sender) + greet.replace("(name)", username));
             }
         }
-        
-        $.say($.getWhisperString(sender) + s.replace("(name)", username));
-    } 
+    }    
 });
+
+$.on('ircChannelJoin', function(event) {
+    var sender = event.getUser().toLowerCase();
+    var username = $.username.resolve(sender);
+
+    $.inidb.set("visited", sender, "visited");
+    
+    if ($.inidb.get("greeting", sender + "_enabled") == "1") {
+        var greet = $.inidb.get("greeting", sender);
+
+        if (greet == null || greet == undefined || greet == "") {
+            $.say($.greetGlobal.replace("(name)", username));
+        } else {
+            $.say(greet.replace("(name)", username));
+        }
+    } else if ($.inidb.get("greeting", "autogreet") == "true") {
+        $.say($.greetGlobal.replace("(name)", username)); 
+    }
+});
+
 setTimeout(function(){ 
     if ($.moduleEnabled('./systems/greetingSystem.js')) {
-        $.registerChatCommand("./systems/greetingSystem.js", "greeting");
         $.registerChatCommand("./systems/greetingSystem.js", "greet");
+        $.registerChatCommand("./systems/greetingSystem.js", "greet toggle");
+        $.registerChatCommand("./systems/greetingSystem.js", "greet toggle default");
+        $.registerChatCommand("./systems/greetingSystem.js", "greet toggle user");
+        $.registerChatCommand("./systems/greetingSystem.js", "greet set");
+        $.registerChatCommand("./systems/greetingSystem.js", "greet set default");
+        $.registerChatCommand("./systems/greetingSystem.js", "greet set user");
     }
-},10*1000);
+}, 10 * 1000);


### PR DESCRIPTION
Fixes / Changes:
  - Improve string handling logic greatly.
  - Get rid of access toggle commands, everything is now merged into "!greet toggle [global OR user <name>]".
  - Get rid of access set commands, everything is now merged into "!greet set [global OR user <name] <message>".
  - Get rid of access "!greet" command, merged it into "!greeting" with no parameters. "!greet" is now an alias for "!greeting".
  - Get rid of redundant on.ircChannelLeave.
  - Fix potential cases where empty parameters could cause errors.
  - Add "!greet max <amount>" to allow Admins to set the max length of greet messages.
  - Add "!greet set user <name> <message>" and "!greet toggle user <name>" to allow Mods to set and toggle other user's greet messages.