### PR TITLE
Fix argument issue causing the command to be in the message

### DIFF
--- a/res/scripts/systems/bankheistSystem.js
+++ b/res/scripts/systems/bankheistSystem.js
@@ -412,7 +412,7 @@ $.on('command', function (event) {
             var modValue = "";
             if(args[1]!=null) {
                 if(isNaN(args[1])) {
-                    modValue = argsString.substring(argsString.indexOf(args[0]) + 1, argsString.length());
+                    modValue = argsString.substring(argsString.indexOf(args[0]) + $.strlen(args[0]) + 1);
                 } else {
                     modValue = args[1];
                 }


### PR DESCRIPTION
Ex;
infantdevilsman: !bankheist stringstarting We've broken the lock on the back door! Let's get in there!
misterdevbot: infantdevilsman: The value for stringStarting has been set to tringstarting We've broken the lock on the back door! Let's get in there