### PR TITLE
added SSL server capability for Sockets

### DIFF
--- a/src/de/simeonf/EventWebSocketSecureServer.java
+++ b/src/de/simeonf/EventWebSocketSecureServer.java
@@ -1,0 +1,78 @@
+/* 
+ * Copyright (C) 2015 www.phantombot.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.simeonf;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import java.security.KeyStore;
+
+import org.java_websocket.server.DefaultSSLWebSocketServerFactory;
+
+
+public class EventWebSocketSecureServer extends EventWebSocketServer
+{
+
+    private static EventWebSocketSecureServer instance;
+
+    public static EventWebSocketSecureServer instance()
+    {
+        return instance;
+    }
+    
+    public EventWebSocketSecureServer(int port)
+    {
+    	this(port, null, null, null);
+	}
+    
+    public EventWebSocketSecureServer(int port, String keystorepath, String keystorepassword, String keypassword)
+    {
+		super(port);
+
+    	try
+		{
+			SSLContext sslContext = SSLContext.getInstance("TLS");
+	
+	    	if (!keystorepath.equals(""))
+	    	{
+				KeyStore ks = KeyStore.getInstance("JKS");
+				ks.load(new FileInputStream(new File(keystorepath)), keystorepassword.toCharArray());
+
+				KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+				kmf.init(ks, keypassword.toCharArray());
+				TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+				tmf.init(ks);
+
+				sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+	    	}
+			else
+			{
+				sslContext.init(null, null, null);
+			}
+	        this.setWebSocketFactory(new DefaultSSLWebSocketServerFactory(sslContext));
+		}
+    	catch(Exception e)
+		{
+	        com.gmt2001.Console.out.println("Secure EventSocketServer failed: " + e);
+	        e.printStackTrace();
+		}
+    }
+}

--- a/src/de/simeonf/EventWebSocketServer.java
+++ b/src/de/simeonf/EventWebSocketServer.java
@@ -45,10 +45,6 @@ public class EventWebSocketServer extends WebSocketServer implements Listener
 		super(new InetSocketAddress(port));
 
         Thread.setDefaultUncaughtExceptionHandler(com.gmt2001.UncaughtExceptionHandler.instance());
-
-        this.start();
-        com.gmt2001.Console.out.println("EventSocketServer accepting connections on port " + port);
-
     }
 
 	@Override

--- a/src/de/simeonf/MusicWebSocketSecureServer.java
+++ b/src/de/simeonf/MusicWebSocketSecureServer.java
@@ -1,0 +1,80 @@
+/* 
+ * Copyright (C) 2015 www.phantombot.net
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.simeonf;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import java.security.KeyStore;
+
+import org.java_websocket.server.DefaultSSLWebSocketServerFactory;
+
+import me.mast3rplan.phantombot.musicplayer.MusicWebSocketServer;
+
+
+public class MusicWebSocketSecureServer extends MusicWebSocketServer
+{
+
+    private static MusicWebSocketSecureServer instance;
+
+    public static MusicWebSocketSecureServer instance()
+    {
+        return instance;
+    }
+    
+    public MusicWebSocketSecureServer(int port)
+    {
+    	this(port, null, null, null);
+	}
+    
+    public MusicWebSocketSecureServer(int port, String keystorepath, String keystorepassword, String keypassword)
+    {
+		super(port);
+
+    	try
+		{
+			SSLContext sslContext = SSLContext.getInstance("TLS");
+	
+	    	if (!keystorepath.equals(""))
+	    	{
+				KeyStore ks = KeyStore.getInstance("JKS");
+				ks.load(new FileInputStream(new File(keystorepath)), keystorepassword.toCharArray());
+
+				KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+				kmf.init(ks, keypassword.toCharArray());
+				TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+				tmf.init(ks);
+
+				sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+	    	}
+			else
+			{
+				sslContext.init(null, null, null);
+			}
+	        this.setWebSocketFactory(new DefaultSSLWebSocketServerFactory(sslContext));
+		}
+    	catch(Exception e)
+		{
+	        com.gmt2001.Console.out.println("Secure EventSocketServer failed: " + e);
+	        e.printStackTrace();
+		}
+    }
+}

--- a/src/me/mast3rplan/phantombot/musicplayer/MusicWebSocketServer.java
+++ b/src/me/mast3rplan/phantombot/musicplayer/MusicWebSocketServer.java
@@ -39,9 +39,6 @@ public class MusicWebSocketServer extends WebSocketServer
         super(new InetSocketAddress(port));
 
         Thread.setDefaultUncaughtExceptionHandler(com.gmt2001.UncaughtExceptionHandler.instance());
-
-        this.start();
-        com.gmt2001.Console.out.println("MusicSockServer accepting connections on port " + port);
     }
 
     @Override


### PR DESCRIPTION
For the readme:
There are 4 new parameters for botlogin.txt:
```
usehttps=true
keystorepath=keystore.jks
keystorepassword=storepassword
keypassword=keypassword
```
If they are not set (or not there), the bot will simply not use https, nothing breaks.
The Keystore is in .jks format, if you want to convert your pem certificate, just use the steps from [here](https://docs.oracle.com/cd/E35976_01/server.740/es_admin/src/tadm_ssl_convert_pem_to_jks.html)