### PR TITLE
Eliminate "Saving 0 files" spam on console

### DIFF
--- a/src/com/gmt2001/IniStore.java
+++ b/src/com/gmt2001/IniStore.java
@@ -228,7 +228,9 @@ public class IniStore extends DataStore implements ActionListener
                     n = files.keySet().toArray();
                 }
 
-                com.gmt2001.Console.out.println(">>>Saving " + n.length + " files");
+                if (n.length > 0) {
+                    com.gmt2001.Console.out.println(">>>Saving " + n.length + " files");
+                }
 
                 for (Object n1 : n)
                 {
@@ -252,7 +254,9 @@ public class IniStore extends DataStore implements ActionListener
 
                 nextSave.setTime(new Date().getTime() + saveInterval);
 
-                com.gmt2001.Console.out.println(">>>Save complete");
+                if (n.length > 0) {
+                    com.gmt2001.Console.out.println(">>>Save complete");
+                }
             } else
             {
                 com.gmt2001.Console.out.println(">>>Object null, nothing to save.");


### PR DESCRIPTION
This change simply disables the save message when 0 files have changed. Seems like non-necessary info.

e.g.:
`>>>Saving 0 files...`
`>>>Save Complete`